### PR TITLE
Now scraping deliverables timeline, and not category and exceptions

### DIFF
--- a/inkind/contribution.py
+++ b/inkind/contribution.py
@@ -124,6 +124,13 @@ class Contribution():
             line = "Not yet available"
         return line
 
+    def timeline(self):
+        try:
+            line = self.text["DELIVERABLES_TIMELINE"]
+        except:
+            line = "Not yet available"
+        return line
+
     def extract_PI_value(self):
         try:
             N = []

--- a/inkind/proposal.py
+++ b/inkind/proposal.py
@@ -50,9 +50,11 @@ class Proposal(HTMLParser):
                   '"'+str(self.contribution[S].LOI_CODE)+'"'+","+
                   '"'+str(self.contribution[S].RECIPIENTS)+'"'+","+
                   '"'+self.contribution[S].one_line_SOW()+'"'+","+
-                  str(self.contribution[S].VALUE)+","+
-                  str(self.contribution[S].EXCEPTION)+","+
-                  str(self.contribution[S].CATEGORY))
+                  '"'+self.contribution[S].timeline()+'"'+","+
+                  str(self.contribution[S].VALUE))
+                  # PJM 2021-04-14: No need to extract exceptions and categories any more, the Tracker includes the category and the exceptions no longer matter
+                  # str(self.contribution[S].EXCEPTION)+","+
+                  # str(self.contribution[S].CATEGORY))
         return
 
     def print_SOW(self):


### PR DESCRIPTION
Simple improvement from Spring 2021, merging now so we can move on to scraping all proposal text.